### PR TITLE
Fix preferredLanguagesAsLocales for some values

### DIFF
--- a/lib/devicelocale.dart
+++ b/lib/devicelocale.dart
@@ -15,7 +15,7 @@ class Devicelocale {
     final String token = (Platform.isIOS) ? "-" : "_";
     try {
       List localeList = info.split(token);
-      if (localeList.length == 2) {
+      if (localeList.length >= 2) {
         return Locale(localeList[0], localeList[1]);
       }
       return Locale(localeList[0]);


### PR DESCRIPTION
For this case,`preferredLanguages` are `[en_US, zh_CN_#Hans, ja_JP]`

![Screenshot_1603177421](https://user-images.githubusercontent.com/1255062/96551978-193ee200-12ee-11eb-9653-bc04ab822d62.png)


`preferredLanguagesAsLocales` should be `[en_US, zh_CN, ja_JP]` but current result is `[en_US, zh, ja_JP]`, and this PR fixed the issue.