### PR TITLE
feat: retrieve country and language

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,8 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
-import 'package:flutter/services.dart';
+
 import 'package:devicelocale/devicelocale.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() => runApp(MyApp());
 
@@ -14,6 +15,8 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   List? _languages = [];
   String? _locale;
+  String? _country;
+  String? _language;
 
   @override
   void initState() {
@@ -25,6 +28,8 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     List? languages = [];
     String? currentLocale;
+    String? country;
+    String? language;
 
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
@@ -37,6 +42,8 @@ class _MyAppState extends State<MyApp> {
     }
     try {
       currentLocale = await Devicelocale.currentLocale;
+      country = await Devicelocale.currentCountry;
+      language = await Devicelocale.currentLanguage;
       print((currentLocale != null)
           ? currentLocale
           : "Unable to get currentLocale");
@@ -52,6 +59,8 @@ class _MyAppState extends State<MyApp> {
     setState(() {
       _languages = languages;
       _locale = currentLocale;
+      _country = country;
+      _language = language;
     });
   }
 
@@ -67,6 +76,10 @@ class _MyAppState extends State<MyApp> {
           children: <Widget>[
             Text("Current locale: "),
             Text('$_locale'),
+            Text("Current country: "),
+            Text('$_country'),
+            Text("Current language: "),
+            Text('$_language'),
             Text("Preferred Languages: "),
             Text(_languages.toString()),
             Padding(

--- a/lib/devicelocale.dart
+++ b/lib/devicelocale.dart
@@ -1,8 +1,9 @@
 /// Copyright (c) 2019-2021, Steve Rogers. All rights reserved. Use of this source code
 /// is governed by an Apache License 2.0 that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:ui';
 import 'dart:io' show Platform;
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
 
@@ -75,5 +76,32 @@ class Devicelocale {
     final String? locale = await _channel.invokeMethod('currentLocale');
     print("testing asLocale");
     return _getAsLocale(locale, null);
+  }
+
+  /// Returns the current country as ISO 3166-1
+  static Future<String?> get currentCountry async {
+    List<String>? data = await _partialData;
+
+    return data?.elementAt(1);
+  }
+
+  /// Returns the current language as ISO 639-1
+  static Future<String?> get currentLanguage async {
+    List<String>? data = await _partialData;
+
+    return data?.elementAt(0);
+  }
+
+  /// Returns the split locale data (language + country code)
+  static Future<List<String>?> get _partialData async {
+    final String? locale = await currentLocale;
+
+    if (locale == null) {
+      return null;
+    }
+
+    String token = kIsWeb || Platform.isIOS ? '-' : '_';
+
+    return locale.split(token);
   }
 }

--- a/test/devicelocale_test.dart
+++ b/test/devicelocale_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../lib/devicelocale.dart';
+
+main() {
+  testWidgets('Can retrieve current country', (WidgetTester tester) async {
+    const MethodChannel channel =
+        const MethodChannel('uk.spiralarm.flutter/devicelocale');
+    channel.setMockMethodCallHandler((MethodCall call) async => 'en_US');
+
+    var widget = FutureBuilder<String?>(
+      future: Devicelocale.currentCountry,
+      builder: (context, snapshot) {
+        return Text(
+          snapshot.data ?? '',
+          textDirection: TextDirection.ltr,
+        );
+      },
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('US'), findsOneWidget);
+  });
+
+  testWidgets('Can retrieve current language', (WidgetTester tester) async {
+    const MethodChannel channel =
+        const MethodChannel('uk.spiralarm.flutter/devicelocale');
+    channel.setMockMethodCallHandler((MethodCall call) async => 'en_US');
+
+    var widget = FutureBuilder<String?>(
+      future: Devicelocale.currentLanguage,
+      builder: (context, snapshot) {
+        return Text(
+          snapshot.data ?? '',
+          textDirection: TextDirection.ltr,
+        );
+      },
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('en'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
**Added**
- Two getters to get from currentLocale:
  -  Country code (ISO 3166-1)
  - Language (ISO 639-1)
- Add tests

**Changed**
- Add country and language in example

**Notes**
- Feature has not been tested on iOS but should be fine