### PR TITLE
[Android] Using a well-formed IETF language tags instead of debug string

### DIFF
--- a/android/src/main/java/com/example/devicelocale/DevicelocalePlugin.java
+++ b/android/src/main/java/com/example/devicelocale/DevicelocalePlugin.java
@@ -11,6 +11,8 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import androidx.core.os.LocaleListCompat;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.os.Build;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -49,7 +51,7 @@ public class DevicelocalePlugin implements MethodCallHandler, FlutterPlugin {
   }
 
   private String getCurrentLocale() {
-    return Locale.getDefault().toString();
+    return getLocaleTag(Locale.getDefault());
   }
 
   private List<String> getPreferredLanguages() {
@@ -58,12 +60,20 @@ public class DevicelocalePlugin implements MethodCallHandler, FlutterPlugin {
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
       LocaleListCompat list = LocaleListCompat.getAdjustedDefault();
       for (int i = 0; i < list.size(); i++) {
-        result.add(list.get(i).toString());
+        result.add(getLocaleTag(list.get(i)));
       }
     } else {
       result.add(getCurrentLocale());
     }
 
     return result;
+  }
+
+  private String getLocaleTag(Locale locale) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      return locale.toLanguageTag();
+    } else {
+      return locale.toString();
+    }
   }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,13 +25,13 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.devicelocale_example"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
**Changes description**

This PR replaces all `Locale#toString()` with `Locale#toLanguageTag()` for Android 5.0 and above.

**Reason for changes**

The plugin returns a debug string instead of a locale tag. For example, instead of `zh_Hant_TW` (`lang_script_country`) we got `zh_TW_#Hant` (`lang_country_#script`). This is contrary to the Dart locale tag format. Dart and [intl](https://pub.dev/packages/intl) package uses IETF BCP 47 format and IANA Language Subtag Registry to determine locale:  https://api.flutter.dev/flutter/dart-ui/Locale-class.html. 
When passing a string like `zh_TW_#Hant` instead of `zh_Hant_TW` to the [intl.Locale.parse](https://pub.dev/documentation/intl/latest/locale/Locale/parse.html) we got a `FormatException`.

The documentation for Android `Locale#toString()` says:
> Returns a string representation of this Locale object, consisting of language, country, variant, script, and extensions as below:
> `language + "_" + country + "_" + (variant + "_#" | "#") + script + "-" + extensions`
>
> **This behavior is designed to support debugging and to be compatible with previous uses of toString that expected language, country, and variant fields only. To represent a Locale as a String for interchange purposes, use [toLanguageTag()](https://developer.android.com/reference/java/util/Locale#toLanguageTag()).**

instead of it, the `Locale#toLanguageTag()` says:
> Returns a well-formed IETF BCP 47 language tag representing this locale. 