### PR TITLE
Support web builds with WASM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0
+
+* 5 Jul 2024 - Support WASM on web
+
 ## 0.7.1
 
 * 11 Mar 2024 - Merge iOS PrivacyInfo PR

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -32,7 +32,6 @@
 /build/
 
 # Web related
-lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols

--- a/example/.metadata
+++ b/example/.metadata
@@ -1,11 +1,11 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled.
+# This file should be version controlled and should not be manually edited.
 
 version:
-  revision: f1875d570e39de09040c8f79aa13cc56baab8db1
-  channel: stable
+  revision: "761747bfc538b5af34aa0d3fac380f1bc331ec49"
+  channel: "stable"
 
 project_type: app
 
@@ -13,11 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: f1875d570e39de09040c8f79aa13cc56baab8db1
-      base_revision: f1875d570e39de09040c8f79aa13cc56baab8db1
+      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+    - platform: android
+      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+    - platform: ios
+      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+    - platform: linux
+      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
     - platform: macos
-      create_revision: f1875d570e39de09040c8f79aa13cc56baab8db1
-      base_revision: f1875d570e39de09040c8f79aa13cc56baab8db1
+      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+    - platform: web
+      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+    - platform: windows
+      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
 
   # User provided section
 

--- a/lib/devicelocale_web.dart
+++ b/lib/devicelocale_web.dart
@@ -1,12 +1,9 @@
 import 'dart:async';
-// In order to *not* need this ignore, consider extracting the "web" version
-// of your plugin as a separate package, instead of inlining it in the same
-// package as the core of your plugin.
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show window;
+import 'dart:js_interop';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:web/web.dart' as web show window;
 
 /// A web implementation of the Devicelocale plugin.
 class DevicelocaleWeb {
@@ -39,12 +36,12 @@ class DevicelocaleWeb {
   }
 
   Future<List?> getPreferredLanguages() {
-    final List? languages = html.window.navigator.languages;
+    final List? languages = web.window.navigator.languages.toDart.map((e) => e.toDart).toList();
     return Future.value(languages);
   }
 
   Future<String?> getCurrentLocale() {
-    final String? locale = html.window.navigator.language;
+    final String? locale = web.window.navigator.language;
     return Future.value(locale);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devicelocale
 description: A Flutter package that can be used to extract the locales that are currently defined on a device with the current locale set as the first in the list.
-version: 0.7.1
+version: 0.8.0
 homepage: https://github.com/magnatronus/flutter-devicelocale
 
 environment:
@@ -13,6 +13,7 @@ dependencies:
 
   flutter_web_plugins:
     sdk: flutter
+  web: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Since the latest Flutter release, when building for web you can include --wasm and it has better performance on most of the platforms.

#62 

See the [official docs](https://docs.flutter.dev/platform-integration/web/wasm)
