### PR TITLE
fix: update compileSdkVersion to 36

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ android {
       namespace 'com.example.devicelocale'
     }
 
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
After I changed my app to compile against the latest Android SDK (36), I got these errors:

<details>
  <summary>Show build Log Output</summary>
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':devicelocale:checkDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 14 issues were found when checking AAR metadata:

       1.  Dependency 'androidx.fragment:fragment:1.7.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       2.  Dependency 'androidx.window:window:1.2.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       3.  Dependency 'androidx.window:window-java:1.2.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       4.  Dependency 'androidx.activity:activity:1.8.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       5.  Dependency 'androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       6.  Dependency 'androidx.lifecycle:lifecycle-livedata:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       7.  Dependency 'androidx.lifecycle:lifecycle-viewmodel:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       8.  Dependency 'androidx.lifecycle:lifecycle-livedata-core:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       9.  Dependency 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      10.  Dependency 'androidx.core:core-ktx:1.13.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      11.  Dependency 'androidx.core:core:1.13.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      12.  Dependency 'androidx.lifecycle:lifecycle-runtime:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      13.  Dependency 'androidx.lifecycle:lifecycle-process:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      14.  Dependency 'androidx.annotation:annotation-experimental:1.4.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :devicelocale is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 20s
Error: Gradle task assembleDebug failed with exit code 1

Exited (1).
</details>

By changing the compileSdk to 36 for the DeviceLocale plugin, I can now compile and run my app.